### PR TITLE
Fixed Bug: Doesn't display Bounding Box

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,7 @@ function App() {
 
   const displayFaceBox = (box) => {
     console.log(box);
-    setBox({ box: box });
+    setBox({ ...box });
   };
 
   const onInputChange = (e) => {


### PR DESCRIPTION
Before the state was something like `box = {box: ...data}` now is `box = {...data}`